### PR TITLE
Use Pydantic settings for configuration from environment variables

### DIFF
--- a/app/config.env
+++ b/app/config.env
@@ -1,4 +1,0 @@
-TEST_TEXT='this is a test'
-PFLINK_MONGODB='mongodb://localhost:27017'
-PFLINK_PFDCM=http://localhost:4005
-PFLINK_PORT=8050

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,11 @@
+from pydantic import BaseSettings, MongoDsn, AnyHttpUrl
+
+
+class Settings(BaseSettings):
+    pfdcm_name: str = 'PFDCMLOCAL'
+    pflink_mongodb: MongoDsn = 'mongodb://localhost:27017'
+    pflink_pfdcm: AnyHttpUrl = 'http://localhost:4005'
+    pflink_port: int = 8050
+
+
+settings = Settings()

--- a/app/controllers/pfdcm.py
+++ b/app/controllers/pfdcm.py
@@ -4,8 +4,9 @@ import requests
 import json
 import os
 import hashlib
+from config import settings
 
-MONGO_DETAILS = os.getenv("PFLINK_MONGODB", "mongodb://localhost:27017")
+MONGO_DETAILS = str(settings.pflink_mongodb)
 client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_DETAILS)
 
 database = client.pfdcms

--- a/app/controllers/workflow.py
+++ b/app/controllers/workflow.py
@@ -15,8 +15,9 @@ from models.workflow import (
 from controllers.pfdcm import (
     retrieve_pfdcm,
 )
+from config import settings
 
-MONGO_DETAILS = os.getenv("PFLINK_MONGODB", "mongodb://localhost:27017")
+MONGO_DETAILS = str(settings.pflink_mongodb)
 client              = motor.motor_asyncio.AsyncIOMotorClient(MONGO_DETAILS)
 database            = client.workflows
 workflow_collection = database.get_collection("workflows_collection")

--- a/app/main.py
+++ b/app/main.py
@@ -2,12 +2,12 @@ import  uvicorn
 from    pymongo             import MongoClient
 import os
 import hashlib
+from config import settings
 
-    
-MONGO_DETAILS = os.getenv("PFLINK_MONGODB", "mongodb://localhost:27017")
-PFDCM_DETAILS = os.getenv('PFLINK_PFDCM', 'http://localhost:4005')
-PFDCM_NAME    = os.getenv('PFDCM_NAME' , 'PFDCMLOCAL')
-PORT          = int(os.getenv('PFLINK_PORT', '8050'))
+MONGO_DETAILS = str(settings.pflink_mongodb)
+PFDCM_DETAILS = str(settings.pflink_pfdcm)
+PFDCM_NAME    = settings.pfdcm_name
+PORT          = settings.pflink_port
 
 client           = MongoClient(MONGO_DETAILS)
 
@@ -48,8 +48,14 @@ def retrieve_pfdcm(service_name: str) -> dict:
 if __name__ == "__main__":
     pfdcm = retrieve_pfdcm(PFDCM_NAME)
     if not pfdcm:
-        pfdcm_port = PFDCM_DETAILS.split(':')[-1]
-        pfdcm_ip   = PFDCM_DETAILS.split(':')[0] + ':' + PFDCM_DETAILS.split(':')[1]
+        # FIXME yo-yo code
+        # pfdcm URL is unnecessarily split into port and IP,
+        # where referenced these two values are always just joined back together.
+        pfdcm_port = settings.pflink_pfdcm.port
+        # FIXME misleading variable name
+        # References of this value expect `pfdcm_ip` to have the scheme prefixed, i.e.
+        # it's always passed to `requests.get` which requires the value to start with "http://" (or similar)
+        pfdcm_ip   = f'{settings.pflink_pfdcm.scheme}://{settings.pflink_pfdcm.host}'
         add_pfdcm(
         {
             "service_name":  PFDCM_NAME,

--- a/app/processes/utils.py
+++ b/app/processes/utils.py
@@ -2,8 +2,9 @@ import json
 import hashlib
 from pymongo import MongoClient
 import os
+from config import settings
 
-MONGO_DETAILS = os.getenv("PFLINK_MONGODB", "mongodb://localhost:27017")
+MONGO_DETAILS = str(settings.pflink_mongodb)
 
 client = MongoClient(MONGO_DETAILS)
 


### PR DESCRIPTION
Currently, pflink uses `os.getenv` to read environment variables for configuration. This PR replaces usage of `os.getenv` in favor of using Pydantic settings, which centralizes the logic while providing input validation and typing. The current behavior is upheld bug-for-bug.